### PR TITLE
Fix workspace path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
         run: flutter build apk
 
       - name: Run MobSF Analysis
-        uses: inm-certi/mobsf-action@v1.2
+        uses: inm-certi/mobsf-action@v1.3
         env:
           INPUT_FILE_NAME: build/app/outputs/apk/app.apk
           SCAN_TYPE: apk

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -e
 
+cd $GITHUB_WORKSPACE
 if [ -z "$INPUT_FILE_NAME" ] || [ ! -f "$INPUT_FILE_NAME" ]; then
   echo "INPUT_FILE_NAME is required to run MobSF action. (INPUT_FILE_NAME = $INPUT_FILE_NAME)"
-  echo "pwd: $PWD"
-  echo "ls -la $INPUT_FILE_NAME"
   exit 126
 fi
 


### PR DESCRIPTION
The input file validation was happening before joining the GitHub
workspace folder. This commit fix it by navigating to workspace path
before validating.